### PR TITLE
btop: enable gpu box

### DIFF
--- a/btop/btop.conf
+++ b/btop/btop.conf
@@ -50,7 +50,7 @@ graph_symbol_net = "default"
 graph_symbol_proc = "default"
 
 #* Manually set which boxes to show. Available values are "cpu mem net proc" and "gpu0" through "gpu5", separate values with whitespace.
-shown_boxes = "cpu mem net proc"
+shown_boxes = "cpu mem net proc gpu0"
 
 #* Update time in milliseconds, recommended 2000 ms or above for better sample times for graphs.
 update_ms = 2000
@@ -101,7 +101,7 @@ cpu_graph_upper = "Auto"
 cpu_graph_lower = "Auto"
 
 #* If gpu info should be shown in the cpu box. Available values = "Auto", "On" and "Off".
-show_gpu_info = "Auto"
+show_gpu_info = "Off"
 
 #* Toggles if the lower CPU graph should be inverted.
 cpu_invert_lower = True


### PR DESCRIPTION
Add gpu0 to the default boxes shown. Also disable gpu from being shown in cpu box. 

On my system I needed to install the "rocm-smi-lib" package to make gpu box work (maybe add to caelestia-meta package?)