### PR TITLE
solved quickshell error on startup

### DIFF
--- a/hypr/hyprland/execs.conf
+++ b/hypr/hyprland/execs.conf
@@ -25,4 +25,4 @@ exec-once = mpris-proxy
 exec-once = caelestia resizer -d
 
 # Start shell
-exec-once = caelestia shell -d
+exec-once = sleep 3 && caelestia shell -d


### PR DESCRIPTION
dependencies caelestia-shell must change to quickshell in PKGBUILD, not quicksehell-git. then to avoid race condition change the # exec-once = caelestia shell -d
to exec-once = sleep 3 && caelestia shell -d
. and it's solved 