### PR TITLE
fix: keybind for window cycle

### DIFF
--- a/hypr/hyprland/keybinds.conf
+++ b/hypr/hyprland/keybinds.conf
@@ -114,7 +114,7 @@ bind = Super+Alt, S, movetoworkspace, special:special
 
 # Window groups
 binde = $kbWindowGroupCycleNext, cyclenext, activewindow
-binde = $kbWindowGroupCycleNext, cyclenext, prev, activewindow
+binde = $kbWindowGroupCyclePrev, cyclenext, prev, activewindow
 binde = Ctrl+Alt, Tab, changegroupactive, f
 binde = Ctrl+Shift+Alt, Tab, changegroupactive, b
 bind = $kbToggleGroup, togglegroup


### PR DESCRIPTION
Fix variable name typo for window cycle keybind: ```$kbWindowGroupCycleNext``` -> ```$kbWindowGroupCyclePrev```.