### PR TITLE
Update install.fish output README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The install script has some options for installing configs for some apps.
 
 ```
 $ ./install.fish -h
-usage: ./install.sh [-h] [--noconfirm] [--spotify] [--vscode] [--discord] [--paru]
+usage: ./install.sh [-h] [--noconfirm] [--spotify] [--vscode] [--discord] [--aur-helper]
 
 options:
   -h, --help                  show this help message and exit
@@ -28,7 +28,7 @@ options:
   --vscode=[codium|code]      install VSCodium (or VSCode)
   --discord                   install Discord (OpenAsar + Equicord)
   --zen                       install Zen browser
-  --paru                      use paru instead of yay as AUR helper
+  --aur-helper=[yay|paru]     the AUR helper to use
 ```
 
 For example:


### PR DESCRIPTION
The README contains outdated options for install.fish, corrected that.