### PR TITLE
Fixed kbWindowGroupCyclePrev keybind going forward

### DIFF
--- a/hypr/hyprland/keybinds.conf
+++ b/hypr/hyprland/keybinds.conf
@@ -113,8 +113,8 @@ bind = Ctrl+Super+Shift, down, movetoworkspace, e+0
 bind = Super+Alt, S, movetoworkspace, special:special
 
 # Window groups
-binde = $kbWindowGroupCycleNext, cyclenext, activewindow
-binde = $kbWindowGroupCyclePrev, cyclenext, prev, activewindow
+binde = $kbWindowGroupCycleNext, cyclenext
+binde = $kbWindowGroupCyclePrev, cyclenext, prev
 binde = Ctrl+Alt, Tab, changegroupactive, f
 binde = Ctrl+Shift+Alt, Tab, changegroupactive, b
 bind = $kbToggleGroup, togglegroup


### PR DESCRIPTION
You can't comma separate dispatcher parameters
"cyclenext, prev, activewidnow" was reading "prev," as an argument and going forward instead

also cyclenext does not take a window parameters so activewindow was doing nothing anyway (maybe you meant to use hist?)