### PR TITLE
add window rules for file chooser and progress dialogs

### DIFF
--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -39,6 +39,27 @@ windowrule = workspace special:music, initialTitle:Spotify( Free)?  # Spotify wa
 windowrule = workspace special:communication, class:discord|equibop|vesktop|whatsapp
 windowrule = workspace special:todo, class:Todoist
 
+# file chooser dialogs
+windowrule = float, title:(Open|Save)( a)? (File|Folder)(s)?
+windowrule = float, title:Select( a)? (File|Folder)(s)?
+# rename dialog for thunar and others
+windowrule = float, title:Rename ".+"
+# copy/move progress dialogs
+windowrule = float, title:(Copy|Move|Delete|Backup)( Progress)?
+
+# zip extraction dialogs
+windowrule = float, title:(Extract|Compress)( Progress)?
+# Archive manager password prompt
+windowrule = float, title:Enter Password
+# Ark, 7zip, etc
+windowrule = float, class:org\.gnome\.FileRoller, title:Extracting( Archive)?( Progress)?
+windowrule = float, class:org\.gnome\.FileRoller, title:Creating( Archive)?( Progress)?
+windowrule = float, class:file-roller, title:Extracting( Archive)?( Progress)?
+windowrule = float, class:file-roller, title:Creating( Archive)?( Progress)?
+windowrule = float, class:org\.gnome\.FileRoller
+windowrule = float, class:org\.kde\.ark
+windowrule = float, class:file-roller
+
 # Dialogs
 windowrule = float, title:(Select|Open)( a)? (File|Folder)(s)?
 windowrule = float, title:File (Operation|Upload)( Progress)?


### PR DESCRIPTION
This pull request expands the window management rules in `hypr/hyprland/rules.conf` to better handle various utility dialogs and file manager operations. The main focus is on ensuring that common dialogs—such as file choosers, rename dialogs, progress windows, and archive manager prompts—are set to float, improving usability and consistency in the user interface.

Dialog and utility window handling improvements:

* Added rules to float file chooser dialogs by matching titles like "Open File", "Save Folder", etc., ensuring these dialogs are not tiled and are easier to interact with.
* Added rules for floating rename dialogs, copy/move/delete/backup progress dialogs, and zip extraction dialogs by matching relevant window titles.
* Added floating rules for archive manager password prompts and for various archive manager applications (Ark, File Roller, 7zip, etc.), both by class and by title, to cover a wide range of archive-related dialogs.