### PR TITLE
Added nwg-displays support

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -30,3 +30,7 @@ source = $hl/keybinds.conf
 # User configs
 exec = mkdir -p $cConf && touch -a $cConf/hypr-user.conf
 source = $cConf/hypr-user.conf
+
+# nwg-displays support
+source = $hypr/monitors.conf
+source = $hypr/workspaces.conf


### PR DESCRIPTION
I added these lines in hyprland.conf to support the generated files of **nwg-displays**.

<img width="389" height="108" alt="image" src="https://github.com/user-attachments/assets/fc939982-dfa5-46c5-a498-629ed1823dc1" />
