### PR TITLE
Add a source in config.fish to add onto fish configs

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -1,5 +1,4 @@
 if status is-interactive
-
     # Starship custom prompt
     starship init fish | source
 
@@ -42,5 +41,5 @@ if status is-interactive
     end
     
     # Custom fish config
-    source ~/.config/caelestia/user-config.fish 2>/dev/null
+    source ~/.config/caelestia/user-config.fish 2> /dev/null
 end


### PR DESCRIPTION
As the title says
This should probably be added to the Q&A on the shell repo and made to create the file automatically when installing

I did not make the file get created automatically because I could not see where in install.fish it creates the ~/.config/caelestia directory, I'm assuming it's part of the caelestia-shell  instead of the dots