### PR TITLE
update install.fish to make wsaction.fish executable

### DIFF
--- a/install.fish
+++ b/install.fish
@@ -163,7 +163,7 @@ fish -c 'rm -f caelestia-meta-*.pkg.tar.zst' 2> /dev/null
 if confirm-overwrite $config/hypr
     log 'Installing hypr* configs...'
     ln -s (realpath hypr) $config/hypr
-    chmod +x $config/hypr/scripts/wsaction.fish
+    chmod u+x $config/hypr/scripts/wsaction.fish
     hyprctl reload
 end
 


### PR DESCRIPTION
This fixes an issue I had where, after installing, I was not able to move windows around with Super+Alt+[NUMBER]. This was because the wsaction.fish was not executable and never running.