### PR TITLE
fix(hypr): correct music toggle bind and add yt-music rule

### DIFF
--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -34,7 +34,7 @@ windowrule = center 1, match:class nwg-look
 
 # Special workspaces
 windowrule = workspace special:sysmon, match:class btop
-windowrule = workspace special:music, match:class feishin|Spotify|Supersonic|Cider
+windowrule = workspace special:music, match:class feishin|Spotify|Supersonic|Cider|com.github.th_ch.youtube_music
 windowrule = workspace special:music, match:initial_title Spotify( Free)?  # Spotify wayland, it has no class for some reason
 windowrule = workspace special:communication, match:class discord|equibop|vesktop|whatsapp
 windowrule = workspace special:todo, match:class Todoist


### PR DESCRIPTION
This PR corrects the music toggle keybind by removing redundant arguments and adds a window rule for YouTube Music to ensure it opens in the correct special workspace.