### PR TITLE
Enable numlock by default in input configuration

### DIFF
--- a/hypr/hyprland/input.conf
+++ b/hypr/hyprland/input.conf
@@ -1,6 +1,6 @@
 input {
     kb_layout = us
-    numlock_by_default = false
+    numlock_by_default = true
     repeat_delay = 250
     repeat_rate = 35
 


### PR DESCRIPTION
This will suit most people's typing habits, but I don't know if it's suitable.