### PR TITLE
hypr: extend game rules for Lutris/Wine and Gamescope

### DIFF
--- a/hypr/hyprland/rules.conf
+++ b/hypr/hyprland/rules.conf
@@ -66,9 +66,9 @@ windowrule = rounding 10, match:class steam
 windowrule = float true, match:title Friends List, match:class steam
 
 # Games (Steam, Lutris/Wine, Gamescope)
-windowrule = opaque true, match:class ^steam_app_|^gamescope$
-windowrule = immediate true, match:class ^steam_app_|^gamescope$  # Allow tearing for games
-windowrule = idle_inhibit always, match:class ^steam_app_|^gamescope$  # Always idle inhibit when playing a game
+windowrule = opaque true, match:class (steam_app_(default|[0-9]+)|gamescope
+windowrule = immediate true, match:class (steam_app_(default|[0-9]+)|gamescope  # Allow tearing for games
+windowrule = idle_inhibit always, match:class (steam_app_(default|[0-9]+)|gamescope  # Always idle inhibit when playing a game
 
 # ATLauncher console
 windowrule = float true, match:class com-atlauncher-App, match:title ATLauncher Console


### PR DESCRIPTION
Games launched via Lutris/Wine use the class `steam_app_default`, which doesn't match the current `steam_app_[0-9]+` pattern. This means they get no tearing or idle inhibit rules, and the 0.95 window opacity makes the wallpaper visible behind the game.

This broadens the pattern to `^steam_app_` to cover both Steam and Lutris/Wine games, adds gamescope support, and makes game windows opaque (same as creative software in #318).

Tested with WoW via Lutris on Hyprland 0.53.3.