### PR TITLE
fix: Update foot config from 'colors' to 'colors-dark'

### DIFF
--- a/foot/foot.ini
+++ b/foot/foot.ini
@@ -14,7 +14,7 @@ lines=10000
 style=beam
 beam-thickness=1.5
 
-[colors]
+[colors-dark]
 alpha=0.78
 
 [key-bindings]


### PR DESCRIPTION
"colors" is deprecated now and "colors-dark" should be used in Foot