### PR TITLE
fix(foot): rename [colors] to [colors-dark]

### DIFF
--- a/foot/foot.ini
+++ b/foot/foot.ini
@@ -14,7 +14,7 @@ lines=10000
 style=beam
 beam-thickness=1.5
 
-[colors]
+[colors-dark]
 alpha=0.78
 
 [key-bindings]


### PR DESCRIPTION
Resolves depreciation warning due to foot 1.26.0-1 update