### PR TITLE
foot: Replaced deprecated "[colors]" in Foot config

### DIFF
--- a/foot/foot.ini
+++ b/foot/foot.ini
@@ -14,7 +14,7 @@ lines=10000
 style=beam
 beam-thickness=1.5
 
-[colors]
+[colors-dark]
 alpha=0.78
 
 [key-bindings]


### PR DESCRIPTION
+ The newest version of foot has deprecated the alias "[colors]" and "[colors2]" in favor of the name "[colors-dark]" and "[colors-light]" respectively. This commit is a minimal change to replace the deprecation.