### PR TITLE
Change kbToggleSpecialWs handle (no close)

### DIFF
--- a/hypr/hyprland/keybinds.conf
+++ b/hypr/hyprland/keybinds.conf
@@ -77,7 +77,7 @@ binde = Super, Page_Down, workspace, +1
 bind = Ctrl+Super, mouse_down, workspace, -10
 bind = Ctrl+Super, mouse_up, workspace, +10
 # Toggle special workspace
-bind = $kbToggleSpecialWs, exec, caelestia toggle specialws
+bind = $kbToggleSpecialWs, exec, caelestia toggle special
 
 # Move window to workspace #
 bind = $kbMoveWinToWs, 1, exec, $wsaction movetoworkspace 1

--- a/hypr/hyprland/keybinds.conf
+++ b/hypr/hyprland/keybinds.conf
@@ -40,7 +40,6 @@ bindl = , XF86AudioPrev, global, caelestia:mediaPrev
 bindl = , XF86AudioStop, global, caelestia:mediaStop
 
 # Kill/restart
-bindr = Ctrl+Super+Shift, R, exec, qs -c caelestia kill
 bindr = Ctrl+Super+Alt, R, exec, qs -c caelestia kill; sleep .1; caelestia shell -d
 
 # Go to workspace #
@@ -76,8 +75,6 @@ binde = Super, Page_Down, workspace, +1
 # Go to workspace group -1/+1
 bind = Ctrl+Super, mouse_down, workspace, -10
 bind = Ctrl+Super, mouse_up, workspace, +10
-# Toggle special workspace
-bind = $kbToggleSpecialWs, exec, caelestia toggle special
 
 # Move window to workspace #
 bind = $kbMoveWinToWs, 1, exec, $wsaction movetoworkspace 1
@@ -111,7 +108,10 @@ binde = Ctrl+Super+Shift, left, movetoworkspace, -1
 # Move window to/from special workspace
 bind = Ctrl+Super+Shift, up, movetoworkspace, special:special
 bind = Ctrl+Super+Shift, down, movetoworkspace, e+0
-bind = Super+Alt, S, movetoworkspace, special:special
+bind = Ctrl+Super+Shift, S, movetoworkspace, special:special
+bind = Ctrl+Super+Shift, M, movetoworkspace, special:music
+bind = Ctrl+Super+Shift, D, movetoworkspace, special:communication
+bind = Ctrl+Super+Shift, R, movetoworkspace, special:todo
 
 # Window groups
 binde = $kbWindowGroupCycleNext, cyclenext
@@ -154,6 +154,7 @@ bind = $kbToggleWindowFloating, togglefloating,
 bind = $kbCloseWindow, killactive,
 
 # Special workspace toggles
+bind = $kbSpecial, exec, caelestia toggle special
 bind = $kbSystemMonitor, exec, caelestia toggle sysmon
 bind = $kbMusic, exec, caelestia toggle music
 bind = $kbCommunication, exec, caelestia toggle communication

--- a/hypr/variables.conf
+++ b/hypr/variables.conf
@@ -57,7 +57,6 @@ $kbGoToWsGroup = Ctrl+Super
 $kbNextWs = Ctrl+Super, right
 $kbPrevWs = Ctrl+Super, left
 
-$kbToggleSpecialWs = Super, S
 
 # Window groups
 $kbWindowGroupCycleNext = Alt, Tab
@@ -76,6 +75,7 @@ $kbToggleWindowFloating = Super+Alt, Space
 $kbCloseWindow = Super, Q
 
 # Special workspace toggles
+$kbSpecial = Super, S
 $kbSystemMonitor = Ctrl+Shift, Escape
 $kbMusic = Super, M
 $kbCommunication = Super, D


### PR DESCRIPTION
This makes $kbToggleSpecialWs not toggle every special workspace but only THE special workspace.

Basically, if you have special:communication, special:music etc. opened, pressing **$kbToggleSpecialWs will change to the special:special workspace instead of closing the communication or music workspaces.**

Most people just press $kbMusic or $kbCommunication again to close their respective workspaces.