### PR TITLE
Add fish conf.d path to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /btop/themes/
 
 /fish/fish_variables
+/fish/conf.d/
 
 .SRCINFO


### PR DESCRIPTION
This allows users to add their own custom configs in conf.d path, which any later changes to the git repository will leave untouched and not conflict