### PR TITLE
fix: slight improvement to spicetify theme

### DIFF
--- a/spicetify/Themes/caelestia/user.css
+++ b/spicetify/Themes/caelestia/user.css
@@ -33,6 +33,17 @@ button,
   display: none !important;
 }
 
+/* Make home page filter chip better */
+/* Apply material color gradient to home page filter chips container */
+.main-home-filterChipsContainer {
+  background: linear-gradient(to bottom, var(--spice-main-elevated), var(--spice-main)) !important;
+}
+
+/* Remove any decorative pseudo-elements inside the home page filter chips section */
+.main-home-filterChipsSection {
+  background: transparent !important;
+}
+
 /* Remove any decorative pseudo-elements inside the home header */
 .search-searchCategory-contentArea::before,
 .search-searchCategory-contentArea::after {
@@ -47,4 +58,71 @@ button,
 
 .main-view-container__scroll-node-child div[style*="--background-base"]:not([style*="--background-base-min-contrast"]) {
   display: none !important;
+}
+
+/* Make playlist looks better */
+/* Remove gradients in playlist */
+.main-entityHeader-backgroundColor,
+.main-actionBarBackground-background {
+  background-color: unset !important;
+  background-image: none;
+}
+
+/* Some Cover shadow */
+.main-entityHeader-shadow {
+  -webkit-box-shadow: 0 4px 20px rgba(var(--spice-rgb-shadow), 0.5);
+  box-shadow: 0 4px 20px rgba(var(--spice-rgb-shadow), 0.5);
+}
+
+/* Playlist Header */
+.main-entityHeader-shadow {
+  border-radius: 6px;
+}
+
+/* Remove empty space above playlist cover and title on narrow viewports */
+.main-entityHeader-container.main-entityHeader-nonWrapped {
+  min-height: 325px;
+  height: 15vh;
+}
+
+/* Apply material gradient to the sticky top bar in playlist */
+.main-topBar-background {
+  background: linear-gradient(to bottom, var(--spice-main-elevated), var(--spice-main)) !important;
+}
+
+/* Apply material gradient to top bar overlay */
+.main-topBar-overlay {
+  background: linear-gradient(to bottom, transparent, var(--spice-main-elevated)) !important;
+  display: block !important;
+}
+
+/* Force gradient on top bar background */
+.main-topBar-background[style*="--background-base"] {
+  --background-base: transparent !important;
+  background: linear-gradient(to bottom, var(--spice-main-elevated), var(--spice-main)) !important;
+}
+
+.playlist-playlist-actionBarBackground-background {
+  visibility: hidden;
+}
+
+/* Scrollbars */
+.os-scrollbar-handle {
+  background: var(--spice-button) !important;
+  border-radius: 8px;
+}
+
+/* Make Scrollbar look better */
+.os-theme-spotify.os-host-transition
+  > .os-scrollbar-vertical
+  > .os-scrollbar-track
+  > .os-scrollbar-handle {
+  border-radius: 8px;
+  width: 4px;
+  background-color: var(--spice-button-disabled);
+}
+.os-theme-spotify.os-host-transition
+  > .os-scrollbar-vertical
+  > .os-scrollbar-track {
+  width: 4px;
 }


### PR DESCRIPTION
Im not sure if it was originally intended or not, but I made some fixes so that playlist header gradient actually match color of the theme.
Also made improvement to home page filter chip (the top chip filter thing), and scrollbars.

**Before:**
<img width="1425" height="484" alt="image" src="https://github.com/user-attachments/assets/87bb5ebe-a12e-4a85-b459-8159587b1148" />
<img width="1450" height="210" alt="image" src="https://github.com/user-attachments/assets/add3fed4-6c05-403a-8c3f-c7ab2a7292cc" />
<img width="822" height="84" alt="image" src="https://github.com/user-attachments/assets/8546c8fd-e49a-4dae-acd1-942c350f6192" />
<img width="189" height="198" alt="image" src="https://github.com/user-attachments/assets/8e1023c3-35f0-4179-a2a5-ce62665c7b0a" />

**After:**
<img width="1449" height="488" alt="image" src="https://github.com/user-attachments/assets/e72a1a30-065d-4271-b767-a609f61f8eaa" />
<img width="1388" height="184" alt="image" src="https://github.com/user-attachments/assets/ef70f007-57fd-4291-830b-ac6091b437d8" />
<img width="795" height="108" alt="image" src="https://github.com/user-attachments/assets/edbbb4f3-4e05-4014-86e1-47f9365879b4" />
<img width="178" height="246" alt="image" src="https://github.com/user-attachments/assets/8d347295-ee72-43aa-884f-0770ba69a808" />

**Full Preview:**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a7cef5f0-2515-41a9-a508-da15e589d871" />
