### PR TITLE
hypr: fix mouse binds and launcher on Hyprland 0.55

### DIFF
--- a/hypr/hyprland/keybinds.conf
+++ b/hypr/hyprland/keybinds.conf
@@ -1,10 +1,56 @@
-exec = hyprctl dispatch submap global
-submap = global
-
 # ## Shell keybinds
 # Launcher
 bindi = Super, Super_L, global, caelestia:launcher
-bindin = Super, catchall, global, caelestia:launcherInterrupt
+# Catchall is only allowed inside submaps, and Hyprland 0.55 broke mouse binds
+# inside named submaps - so the global submap wrapper is gone and the catchall
+# is replaced by explicit interrupts below.
+# Interrupt on secondary modifier press (covers all Super+Mod+<key> combos)
+bindin = Super, Ctrl_L, global, caelestia:launcherInterrupt
+bindin = Super, Ctrl_R, global, caelestia:launcherInterrupt
+bindin = Super, Shift_L, global, caelestia:launcherInterrupt
+bindin = Super, Shift_R, global, caelestia:launcherInterrupt
+bindin = Super, Alt_L, global, caelestia:launcherInterrupt
+bindin = Super, Alt_R, global, caelestia:launcherInterrupt
+# Interrupt on every key used in a plain Super+<key> bind
+bindin = Super, 0, global, caelestia:launcherInterrupt
+bindin = Super, 1, global, caelestia:launcherInterrupt
+bindin = Super, 2, global, caelestia:launcherInterrupt
+bindin = Super, 3, global, caelestia:launcherInterrupt
+bindin = Super, 4, global, caelestia:launcherInterrupt
+bindin = Super, 5, global, caelestia:launcherInterrupt
+bindin = Super, 6, global, caelestia:launcherInterrupt
+bindin = Super, 7, global, caelestia:launcherInterrupt
+bindin = Super, 8, global, caelestia:launcherInterrupt
+bindin = Super, 9, global, caelestia:launcherInterrupt
+bindin = Super, C, global, caelestia:launcherInterrupt
+bindin = Super, Comma, global, caelestia:launcherInterrupt
+bindin = Super, D, global, caelestia:launcherInterrupt
+bindin = Super, E, global, caelestia:launcherInterrupt
+bindin = Super, Equal, global, caelestia:launcherInterrupt
+bindin = Super, F, global, caelestia:launcherInterrupt
+bindin = Super, G, global, caelestia:launcherInterrupt
+bindin = Super, K, global, caelestia:launcherInterrupt
+bindin = Super, L, global, caelestia:launcherInterrupt
+bindin = Super, M, global, caelestia:launcherInterrupt
+bindin = Super, Minus, global, caelestia:launcherInterrupt
+bindin = Super, N, global, caelestia:launcherInterrupt
+bindin = Super, P, global, caelestia:launcherInterrupt
+bindin = Super, Page_Down, global, caelestia:launcherInterrupt
+bindin = Super, Page_Up, global, caelestia:launcherInterrupt
+bindin = Super, Period, global, caelestia:launcherInterrupt
+bindin = Super, Q, global, caelestia:launcherInterrupt
+bindin = Super, R, global, caelestia:launcherInterrupt
+bindin = Super, S, global, caelestia:launcherInterrupt
+bindin = Super, T, global, caelestia:launcherInterrupt
+bindin = Super, U, global, caelestia:launcherInterrupt
+bindin = Super, V, global, caelestia:launcherInterrupt
+bindin = Super, W, global, caelestia:launcherInterrupt
+bindin = Super, X, global, caelestia:launcherInterrupt
+bindin = Super, Z, global, caelestia:launcherInterrupt
+bindin = Super, down, global, caelestia:launcherInterrupt
+bindin = Super, left, global, caelestia:launcherInterrupt
+bindin = Super, right, global, caelestia:launcherInterrupt
+bindin = Super, up, global, caelestia:launcherInterrupt
 bindin = Super, mouse:272, global, caelestia:launcherInterrupt
 bindin = Super, mouse:273, global, caelestia:launcherInterrupt
 bindin = Super, mouse:274, global, caelestia:launcherInterrupt
@@ -139,10 +185,10 @@ binde = Super+Alt, left, resizeactive, -10% 0
 binde = Super+Alt, right, resizeactive, 10% 0
 binde = Super+Alt, up, resizeactive, 0 -10%
 binde = Super+Alt, down, resizeactive, 0 10%
-bindm = Super, mouse:272, movewindow
-bindm = $kbMoveWindow, movewindow
-bindm = Super, mouse:273, resizewindow
-bindm = $kbResizeWindow, resizewindow
+bindm = Super, mouse:272, drag
+bindm = $kbMoveWindow, drag
+bindm = Super, mouse:273, resize
+bindm = $kbResizeWindow, resize
 bind = Ctrl+Super, Backslash, centerwindow, 1
 bind = Ctrl+Super+Alt, Backslash, resizeactive, exact 55% 70%
 bind = Ctrl+Super+Alt, Backslash, centerwindow, 1


### PR DESCRIPTION
Fixes #436, fixes #434, related: caelestia-dots/shell#1535

## Problem

Hyprland 0.55 broke two things in the current keybinds config:

1. **Mouse binds no longer fire inside named submaps.** The config wraps every bind in `submap = global` (needed for the `catchall` launcher interrupt). Since 0.55, any bind on `mouse:NNN` / `mouse_up` / `mouse_down` inside a named submap silently never triggers — Super+drag, Super+resize and Super+scroll workspace switching are all dead. Keyboard binds in the same submap keep working, which makes this very confusing to debug.

2. **`bindm` dispatchers `movewindow`/`resizewindow` were renamed to `drag`/`resize`.** The old names fail silently — the binds never register (`hyprctl binds` shows no `mouse:272`/`mouse:273` entries at all).

## Fix

- Remove the `submap = global` wrapper so binds live in the default submap, where mouse binds work.
- `catchall` is only allowed inside submaps, so replace it with explicit interrupts:
  - interrupts on secondary-modifier presses (`Ctrl_L/R`, `Shift_L/R`, `Alt_L/R`) — these cover every `Super+Mod+<key>` combo at the moment the second modifier goes down
  - one interrupt per key used in a plain `Super+<key>` bind (generated from this repo's binds)
- Rename the four `bindm` dispatchers to `drag`/`resize`.

## Tested

Daily-driven on Hyprland 0.55.3 + caelestia-shell 2.0.2 + quickshell-git 0.3.0:
- Super tap → launcher opens
- Super+T / Super+Q / Super+1-0 / Super+Shift+arrows → action fires, launcher stays closed
- Super+drag / Super+resize / Super+scroll → all work again
- `hyprctl configerrors` clean

## Notes

- Trade-off vs the old catchall: keys *not* bound to anything under Super won't interrupt the launcher. In practice every Super-combo in this config is covered via the modifier + per-key interrupts.