### PR TITLE
fix: touchScrollFactor not taking effect

### DIFF
--- a/hypr/variables.lua
+++ b/hypr/variables.lua
@@ -14,7 +14,7 @@ return {
 
     -- Touchpad
     touchpadDisableTyping      = true,
-    touchScrollFactor          = 0.3,
+    touchpadScrollFactor          = 0.3,
     gestureFingers             = 3,
     workspaceSwipeFingers      = 4,
     gestureFingersMore         = 4,


### PR DESCRIPTION
input.lua references a touchpadScrollFactor but variables.lua defined a touchScrollFactor

I've chosen to rename the one in variables.lua rather than input.lua to Unify touchpadDisableTyping and touchScrollFactor 