### PR TITLE
fix(hypr): resizer targets matched window, match Bitwarden by class

### DIFF
--- a/hypr/hyprland/execs.lua
+++ b/hypr/hyprland/execs.lua
@@ -30,6 +30,9 @@ hl.on("hyprland.start", function()
 end)
 
 -- Resizer listener
+local bitwarden_extension_title = "^Extension: %(Bitwarden Password Manager%) %- Bitwarden"
+local bitwarden_chromium_extension_id = "nngceckbapebfimnlniiiahkandclblb"
+
 hl.on("window.title", function(win)
     local d = {
         hl.dsp.window.float({ action = "on", window = win }),
@@ -38,6 +41,8 @@ hl.on("window.title", function(win)
     local pip = fn.move_actions(win) or {}
 
     fn.resizer(win, "Bitwarden", 20, 54, d, true, "class")
+    fn.resizer(win, bitwarden_extension_title, 20, 54, d, false)
+    fn.resizer(win, bitwarden_chromium_extension_id, 20, 54, d, true, "class")
     fn.resizer(win, "Picture[- ]in[- ][Pp]icture", 0, 0, pip, false)
 end)
 
@@ -49,5 +54,7 @@ hl.on("window.open", function(win)
     local pip = fn.move_actions(win) or {}
 
     fn.resizer(win, "Bitwarden", 20, 54, d, true, "class")
+    fn.resizer(win, bitwarden_extension_title, 20, 54, d, false)
+    fn.resizer(win, bitwarden_chromium_extension_id, 20, 54, d, true, "class")
     fn.resizer(win, "Picture[- ]in[- ][Pp]icture", 0, 0, pip, false)
 end)

--- a/hypr/hyprland/execs.lua
+++ b/hypr/hyprland/execs.lua
@@ -39,6 +39,7 @@ local function apply_resizer_rules(win)
 
     fn.resizer(win, "Bitwarden", 20, 54, bitwarden_actions, true, "class")
     fn.resizer(win, "^Extension: %(Bitwarden Password Manager%) %- Bitwarden", 20, 54, bitwarden_actions, false)
+    -- Bitwarden Chromium extension ID
     fn.resizer(win, "nngceckbapebfimnlniiiahkandclblb", 20, 54, bitwarden_actions, true, "class")
     fn.resizer(win, "Picture[- ]in[- ][Pp]icture", 0, 0, pip_actions, false)
 end

--- a/hypr/hyprland/execs.lua
+++ b/hypr/hyprland/execs.lua
@@ -37,7 +37,7 @@ hl.on("window.title", function(win)
     }
     local pip = fn.move_actions(win) or {}
 
-    fn.resizer(win, "Bitwarden", 20, 54, d, true)
+    fn.resizer(win, "Bitwarden", 20, 54, d, true, "class")
     fn.resizer(win, "Picture[- ]in[- ][Pp]icture", 0, 0, pip, false)
 end)
 
@@ -48,6 +48,6 @@ hl.on("window.open", function(win)
     }
     local pip = fn.move_actions(win) or {}
 
-    fn.resizer(win, "Bitwarden", 20, 54, d, true)
+    fn.resizer(win, "Bitwarden", 20, 54, d, true, "class")
     fn.resizer(win, "Picture[- ]in[- ][Pp]icture", 0, 0, pip, false)
 end)

--- a/hypr/hyprland/execs.lua
+++ b/hypr/hyprland/execs.lua
@@ -29,32 +29,19 @@ hl.on("hyprland.start", function()
     hl.exec_cmd("caelestia shell -d")
 end)
 
--- Resizer listener
-local bitwarden_extension_title = "^Extension: %(Bitwarden Password Manager%) %- Bitwarden"
-local bitwarden_chromium_extension_id = "nngceckbapebfimnlniiiahkandclblb"
-
-hl.on("window.title", function(win)
-    local d = {
+-- Resizer listeners
+local function apply_resizer_rules(win)
+    local bitwarden_actions = {
         hl.dsp.window.float({ action = "on", window = win }),
         hl.dsp.window.center({ window = win }),
     }
-    local pip = fn.move_actions(win) or {}
+    local pip_actions = fn.move_actions(win) or {}
 
-    fn.resizer(win, "Bitwarden", 20, 54, d, true, "class")
-    fn.resizer(win, bitwarden_extension_title, 20, 54, d, false)
-    fn.resizer(win, bitwarden_chromium_extension_id, 20, 54, d, true, "class")
-    fn.resizer(win, "Picture[- ]in[- ][Pp]icture", 0, 0, pip, false)
-end)
+    fn.resizer(win, "Bitwarden", 20, 54, bitwarden_actions, true, "class")
+    fn.resizer(win, "^Extension: %(Bitwarden Password Manager%) %- Bitwarden", 20, 54, bitwarden_actions, false)
+    fn.resizer(win, "nngceckbapebfimnlniiiahkandclblb", 20, 54, bitwarden_actions, true, "class")
+    fn.resizer(win, "Picture[- ]in[- ][Pp]icture", 0, 0, pip_actions, false)
+end
 
-hl.on("window.open", function(win)
-    local d = {
-        hl.dsp.window.float({ action = "on", window = win }),
-        hl.dsp.window.center({ window = win }),
-    }
-    local pip = fn.move_actions(win) or {}
-
-    fn.resizer(win, "Bitwarden", 20, 54, d, true, "class")
-    fn.resizer(win, bitwarden_extension_title, 20, 54, d, false)
-    fn.resizer(win, bitwarden_chromium_extension_id, 20, 54, d, true, "class")
-    fn.resizer(win, "Picture[- ]in[- ][Pp]icture", 0, 0, pip, false)
-end)
+hl.on("window.title", apply_resizer_rules)
+hl.on("window.open", apply_resizer_rules)

--- a/hypr/hyprland/execs.lua
+++ b/hypr/hyprland/execs.lua
@@ -31,16 +31,18 @@ end)
 
 -- Resizer listeners
 local function apply_resizer_rules(win)
-    local bitwarden_actions = {
+    local float_center = {
         hl.dsp.window.float({ action = "on", window = win }),
         hl.dsp.window.center({ window = win }),
     }
     local pip_actions = fn.move_actions(win) or {}
 
-    fn.resizer(win, "Bitwarden", 20, 54, bitwarden_actions, true, "class")
-    fn.resizer(win, "^Extension: %(Bitwarden Password Manager%) %- Bitwarden", 20, 54, bitwarden_actions, false)
-    -- Bitwarden Chromium extension ID
-    fn.resizer(win, "nngceckbapebfimnlniiiahkandclblb", 20, 54, bitwarden_actions, true, "class")
+    -- Bitwarden
+    fn.resizer(win, "Bitwarden", 20, 54, float_center, true, "class")                                       -- Native app
+    fn.resizer(win, "^Extension: %(Bitwarden Password Manager%) %- Bitwarden", 20, 54, float_center, false) -- Firefox
+    fn.resizer(win, "nngceckbapebfimnlniiiahkandclblb", 20, 54, float_center, true, "class")                -- Chromium
+
+    -- Picture in picture
     fn.resizer(win, "Picture[- ]in[- ][Pp]icture", 0, 0, pip_actions, false)
 end
 

--- a/hypr/utils/functions.lua
+++ b/hypr/utils/functions.lua
@@ -41,15 +41,23 @@ local function resize_active_window(x, y)
     end
 end
 
-local function resizer(window, pattern, x_percent, y_percent, actions, exact)
-    if (window and window.title) and string.find(window.title, pattern, 1, exact) then
+local function resizer(window, pattern, x_percent, y_percent, actions, exact, field)
+    local value = window and window[field or "title"]
+    if value and string.find(value, pattern, 1, exact) then
         local disp = (type(actions) == "table") and actions or { actions }
         for _, x in ipairs(disp) do
             hl.dispatch(x)
         end
 
-        hl.dispatch(hl.dsp.window.resize(resize_by_screen(x_percent, y_percent)))
-        hl.dispatch(hl.dsp.window.set_prop({ prop = "keep_aspect_ratio", value = "true" }))
+        -- Target the matched window explicitly. Without window=, resize/set_prop
+        -- act on the currently focused window instead, mangling whatever tiled
+        -- window happened to be focused when this matched.
+        local sz = resize_by_screen(x_percent, y_percent)
+        if sz then
+            sz.window = window
+            hl.dispatch(hl.dsp.window.resize(sz))
+        end
+        hl.dispatch(hl.dsp.window.set_prop({ prop = "keep_aspect_ratio", value = "true", window = window }))
     end
 end
 


### PR DESCRIPTION
Fixes #458.

Two fixes to the Bitwarden/PiP `resizer()`:

1. **Resizes the matched window, not the focused one.** `resize`/`set_prop` were missing `window=` (unlike `float`/`center` right above them, and unlike `move_actions()`), so opening Bitwarden while a tiled window was focused resized *that* window to 20%×54% and aspect-locked it. Now passes `window=` explicitly, plus a nil-guard for the `resize_by_screen(0, 0)` case the PiP rule uses.
2. **Matches Bitwarden by class instead of title substring**, so a browser tab or terminal whose title merely contains "Bitwarden" no longer gets floated. `resizer()` gains an optional `field` arg — defaults to `title`, so the PiP rule is unchanged.

Tested locally: the real Bitwarden app still floats/centers/resizes as before, and a terminal titled "Bitwarden" now stays put.
