### PR TITLE
fix(hypr): correct Spotify initial-title regex

### DIFF
--- a/hypr/hyprland/rules.lua
+++ b/hypr/hyprland/rules.lua
@@ -113,7 +113,7 @@ hl.window_rule({
     },
     workspace = "special:music",
 })
-hl.window_rule({ match = { initial_title = "Spotify( %(?Free%)?)?" }, workspace = "special:music" }) -- Spotify wayland, it has no class for some reason
+hl.window_rule({ match = { initial_title = "^(Spotify|Spotify Free)$" }, workspace = "special:music" }) -- Spotify wayland, it has no class for some reason
 hl.window_rule({ match = { class = "discord|equibop|vesktop|whatsapp" }, workspace = "special:communication" })
 hl.window_rule({ match = { class = "Todoist" }, workspace = "special:todo" })
 


### PR DESCRIPTION
## Summary

- replace the malformed mixed Lua-pattern/RE2 Spotify initial-title expression with valid RE2 syntax
- match the intended `Spotify` and `Spotify Free` titles without emitting startup errors

Closes #464

## Testing

- `luac -p hypr/hyprland/rules.lua`
- verified the expression matches `Spotify` and `Spotify Free` but not `Spotify Premium`
- applied the same change to Hyprland 0.55.4 and confirmed `hyprctl configerrors` returns no errors
