### PR TITLE
hyprland: correct window class for youtube-music

### DIFF
--- a/hypr/hyprland/rules.lua
+++ b/hypr/hyprland/rules.lua
@@ -109,7 +109,7 @@ hl.window_rule({
 hl.window_rule({ match = { class = "btop" }, workspace = "special:sysmon" })
 hl.window_rule({
     match     = {
-        class = "feishin|Spotify|Supersonic|Cider|com.github.th_ch.youtube_music|Plexamp|com-maxrave-simpmusic-MainKt",
+        class = "feishin|Spotify|Supersonic|Cider|com.github.th-ch.youtube-music|Plexamp|com-maxrave-simpmusic-MainKt",
     },
     workspace = "special:music",
 })


### PR DESCRIPTION
**What this PR does**
Updates the window class for the YouTube Music application from `com.github.th_ch.youtube_music` to `com.github.th-ch.youtube-music` in `hypr/hyprland/rules.lua`. 

The upstream application (Pear Desktop / YouTube Music) uses hyphens for its window class, causing the current `special:music` workspace rule to fail.

**Testing**
Tested locally. The rule now successfully catches the window. Here is the verified class output from `hyprctl clients`:

Window 5619d79ac940 -> YouTube Music:
	class: com.github.th-ch.youtube-music
	title: YouTube Music
	initialClass: com.github.th-ch.youtube-music


**Side effects / Breaking changes**
None. This only restores intended behavior for users running this specific media player.