### PR TITLE
feat!: add new keybind variables and improve bind management

### DIFF
--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -1,112 +1,108 @@
 local vars = require("variables")
 local fn   = require("utils.functions")
 
+local locked           = { locked = true }
+local mouse            = { mouse = true }
+local release          = { release = true }
+local repeating        = { repeating = true }
+local locked_repeating = { locked = true, repeating = true }
+
+local function create_bind(keybinds, action, flags)
+    local keys = type(keybinds) == "string" and { keybinds } or keybinds
+
+    for _, keybind in ipairs(keybinds) do
+        hl.bind(keybind, action, flags)
+    end
+end
+
 -- Launcher
-hl.bind("SUPER + SUPER_L", hl.dsp.global("caelestia:launcher"), { release = true })
+create_bind("SUPER + SUPER_L", hl.dsp.global("caelestia:launcher"), release)
 
 -- Misc
-hl.bind(vars.kbSession, hl.dsp.global("caelestia:session"))
-hl.bind(vars.kbShowSidebar, hl.dsp.global("caelestia:sidebar"))
-hl.bind(vars.kbClearNotifs, hl.dsp.global("caelestia:clearNotifs"), { locked = true })
-hl.bind(vars.kbShowPanels, hl.dsp.global("caelestia:showall"))
-hl.bind(vars.kbLock, hl.dsp.global("caelestia:lock"))
+create_bind(vars.kbSession, hl.dsp.global("caelestia:session"))
+create_bind(vars.kbShowSidebar, hl.dsp.global("caelestia:sidebar"))
+create_bind(vars.kbClearNotifs, hl.dsp.global("caelestia:clearNotifs"), locked)
+create_bind(vars.kbShowPanels, hl.dsp.global("caelestia:showall"))
+create_bind(vars.kbLock, hl.dsp.global("caelestia:lock"))
 
 -- Restore lock
-hl.bind(vars.kbRestoreLock, function()
+create_bind(vars.kbRestoreLock, function()
     hl.dispatch(hl.dsp.exec_cmd("caelestia shell -d"))
     hl.dispatch(hl.dsp.global("caelestia:lock"))
 end)
 
--- Brightness
-hl.bind("XF86MonBrightnessUp", hl.dsp.global("caelestia:brightnessUp"), { locked = true })
-hl.bind("XF86MonBrightnessDown", hl.dsp.global("caelestia:brightnessDown"), { locked = true })
-
--- Media
-hl.bind("CTRL + SUPER + Space", hl.dsp.global("caelestia:mediaToggle"), { locked = true })
-hl.bind("XF86AudioPlay", hl.dsp.global("caelestia:mediaToggle"), { locked = true })
-hl.bind("XF86AudioPause", hl.dsp.global("caelestia:mediaToggle"), { locked = true })
-hl.bind("CTRL + SUPER + Equal", hl.dsp.global("caelestia:mediaNext"), { locked = true })
-hl.bind("XF86AudioNext", hl.dsp.global("caelestia:mediaNext"), { locked = true })
-hl.bind("CTRL + SUPER + Minus", hl.dsp.global("caelestia:mediaPrev"), { locked = true })
-hl.bind("XF86AudioPrev", hl.dsp.global("caelestia:mediaPrev"), { locked = true })
-hl.bind("XF86AudioStop", hl.dsp.global("caelestia:mediaStop"), { locked = true })
-
 -- Kill/restart
-hl.bind("CTRL + SUPER + SHIFT + R", hl.dsp.exec_cmd("qs -c caelestia kill"), { release = true })
-hl.bind(
+create_bind("CTRL + SUPER + SHIFT + R", hl.dsp.exec_cmd("qs -c caelestia kill"), release)
+create_bind(
     "CTRL + SUPER + ALT + R",
     hl.dsp.exec_cmd("qs -c caelestia kill; sleep .1; caelestia shell -d"),
-    { release = true }
+    release
 )
 
 for i = 1, 10 do
     local key = i % 10 -- 10 maps to key 0
-    hl.bind(vars.kbGoToWs .. " + " .. key, fn.wsaction("focus", "", i))
-    hl.bind(vars.kbMoveWinToWs .. " + " .. key, fn.wsaction("move", "", i))
-    hl.bind(vars.kbGoToWsGroup .. " + " .. key, fn.wsaction("focus", "group", i))
-    hl.bind(vars.kbMoveWinToWsGroup .. " + " .. key, fn.wsaction("move", "group", i))
+    create_bind(vars.kbGoToWs .. " + " .. key, fn.wsaction("focus", "", i))
+    create_bind(vars.kbMoveWinToWs .. " + " .. key, fn.wsaction("move", "", i))
+    create_bind(vars.kbGoToWsGroup .. " + " .. key, fn.wsaction("focus", "group", i))
+    create_bind(vars.kbMoveWinToWsGroup .. " + " .. key, fn.wsaction("move", "group", i))
 end
 
 -- Go to workspace -1/+1
-hl.bind("SUPER + mouse_up", hl.dsp.focus({ workspace = "-1" }))
-hl.bind("SUPER + mouse_down", hl.dsp.focus({ workspace = "+1" }))
-hl.bind(vars.kbPrevWs, hl.dsp.focus({ workspace = "-1" }), { repeating = true })
-hl.bind(vars.kbNextWs, hl.dsp.focus({ workspace = "+1" }), { repeating = true })
-hl.bind("SUPER + Page_Up", hl.dsp.focus({ workspace = "-1" }), { repeating = true })
-hl.bind("SUPER + Page_down", hl.dsp.focus({ workspace = "+1" }), { repeating = true })
+create_bind("SUPER + mouse_up", hl.dsp.focus({ workspace = "-1" }))
+create_bind("SUPER + mouse_down", hl.dsp.focus({ workspace = "+1" }))
+create_bind({ vars.kbPrevWs, "SUPER + Page_Up" }, hl.dsp.focus({ workspace = "-1" }), repeating)
+create_bind({ vars.kbNextWs, "SUPER + Page_Down" }, hl.dsp.focus({ workspace = "+1" }), repeating)
 
 -- Go to workspace group -1/+1
-hl.bind("CTRL + SUPER + mouse_up", hl.dsp.focus({ workspace = "-10" }))
-hl.bind("CTRL + SUPER + mouse_down", hl.dsp.focus({ workspace = "+10" }))
+create_bind("CTRL + SUPER + mouse_up", hl.dsp.focus({ workspace = "-10" }))
+create_bind("CTRL + SUPER + mouse_down", hl.dsp.focus({ workspace = "+10" }))
 
 -- Move window to workspace -1/+1
-hl.bind("SUPER + ALT + Page_Up", hl.dsp.window.move({ workspace = "-1" }), { repeating = true })
-hl.bind("SUPER + ALT + Page_Down", hl.dsp.window.move({ workspace = "+1" }), { repeating = true })
-hl.bind("SUPER + ALT + mouse_up", hl.dsp.window.move({ workspace = "-1" }))
-hl.bind("SUPER + ALT + mouse_down", hl.dsp.window.move({ workspace = "+1" }))
-hl.bind("CTRL + SUPER + SHIFT + right", hl.dsp.window.move({ workspace = "+1" }), { repeating = true })
-hl.bind("CTRL + SUPER + SHIFT + left", hl.dsp.window.move({ workspace = "-1" }), { repeating = true })
+create_bind("SUPER + ALT + mouse_up", hl.dsp.window.move({ workspace = "-1" }))
+create_bind("SUPER + ALT + mouse_down", hl.dsp.window.move({ workspace = "+1" }))
+create_bind(
+    { "SUPER + ALT + Page_Down", "CTRL + SUPER + SHIFT + right" },
+    hl.dsp.window.move({ workspace = "+1" }),
+    repeating
+)
+create_bind(
+    { "SUPER + ALT + Page_Up", "CTRL + SUPER + SHIFT + left" },
+    hl.dsp.window.move({ workspace = "-1" }),
+    repeating
+)
 
 -- Move window to/from special workspace
-hl.bind("CTRL + SUPER + SHIFT + up", hl.dsp.window.move({ workspace = "special:special" }))
-hl.bind("CTRL + SUPER + SHIFT + down", hl.dsp.window.move({ workspace = "e+0" }))
-hl.bind("SUPER + ALT + S", hl.dsp.window.move({ workspace = "special:special" }))
+create_bind({ vars.kbMoveWinToWsSpecial, "CTRL + SUPER + SHIFT + up" }, hl.dsp.window.move({ workspace = "special:special" }))
+create_bind("CTRL + SUPER + SHIFT + down", hl.dsp.window.move({ workspace = "e+0" }))
 
 -- Window groups
-hl.bind(vars.kbWindowGroupCycleNext, hl.dsp.window.cycle_next(), { repeating = true })
-hl.bind(vars.kbWindowGroupCyclePrev, hl.dsp.window.cycle_next({ next = false }), { repeating = true })
-hl.bind("CTRL + ALT + Tab", hl.dsp.group.next(), { repeating = true })
-hl.bind("CTRL + SHIFT + ALT + Tab", hl.dsp.group.prev(), { repeating = true })
-hl.bind(vars.kbToggleGroup, hl.dsp.group.toggle())
-hl.bind(vars.kbUngroup, hl.dsp.window.move({ out_of_group = true }))
-hl.bind("SUPER + SHIFT + Comma", hl.dsp.group.lock_active())
+create_bind(vars.kbWindowGroupCycleNext, hl.dsp.window.cycle_next(), repeating)
+create_bind(vars.kbWindowGroupCyclePrev, hl.dsp.window.cycle_next({ next = false }), repeating)
+create_bind("CTRL + ALT + Tab", hl.dsp.group.next(), repeating)
+create_bind("CTRL + SHIFT + ALT + Tab", hl.dsp.group.prev(), repeating)
+create_bind(vars.kbToggleGroup, hl.dsp.group.toggle())
+create_bind(vars.kbUngroup, hl.dsp.window.move({ out_of_group = true }))
+create_bind("SUPER + SHIFT + Comma", hl.dsp.group.lock_active())
 
 -- Window actions
-hl.bind("SUPER + left", hl.dsp.focus({ direction = "left" }))
-hl.bind("SUPER + right", hl.dsp.focus({ direction = "right" }))
-hl.bind("SUPER + up", hl.dsp.focus({ direction = "up" }))
-hl.bind("SUPER + down", hl.dsp.focus({ direction = "down" }))
-hl.bind("SUPER + SHIFT + left", hl.dsp.window.move({ direction = "left" }))
-hl.bind("SUPER + SHIFT + right", hl.dsp.window.move({ direction = "right" }))
-hl.bind("SUPER + SHIFT + up", hl.dsp.window.move({ direction = "up" }))
-hl.bind("SUPER + SHIFT + down", hl.dsp.window.move({ direction = "down" }))
-hl.bind("SUPER + Minus", fn.resize_active_window(-10, 0), { repeating = true })
-hl.bind("SUPER + Equal", fn.resize_active_window(10, 0), { repeating = true })
-hl.bind("SUPER + SHIFT + Minus", fn.resize_active_window(0, -10), { repeating = true })
-hl.bind("SUPER + SHIFT + Equal", fn.resize_active_window(0, 10), { repeating = true })
-hl.bind("SUPER + ALT + left", fn.resize_active_window(-10, 0), { repeating = true })
-hl.bind("SUPER + ALT + right", fn.resize_active_window(10, 0), { repeating = true })
-hl.bind("SUPER + ALT + up", fn.resize_active_window(0, -10), { repeating = true })
-hl.bind("SUPER + ALT + down", fn.resize_active_window(0, 10), { repeating = true })
+for _, dir in ipairs({ "left", "right", "up", "down" }) do
+    create_bind("SUPER + " .. dir, hl.dsp.focus({ direction = dir }))
+    create_bind("SUPER + SHIFT + " .. dir, hl.dsp.window.move({ direction = dir }))
+end
 
-hl.bind("SUPER + mouse:272", hl.dsp.window.drag(), { mouse = true })
-hl.bind(vars.kbMoveWindow, hl.dsp.window.drag(), { mouse = true })
-hl.bind("SUPER + mouse:273", hl.dsp.window.resize(), { mouse = true })
-hl.bind(vars.kbResizeWindow, hl.dsp.window.resize(), { mouse = true })
-hl.bind("CTRL + SUPER + Backslash", hl.dsp.window.center())
-hl.bind("CTRL + SUPER + ALT + Backslash", hl.dsp.window.resize(fn.resize_by_screen(55, 70)))
-hl.bind("CTRL + SUPER + ALT + Backslash", hl.dsp.window.center())
-hl.bind(vars.kbWindowPip, function()
+create_bind({ "SUPER + Minus", "SUPER + ALT + left" }, fn.resize_active_window(-10, 0), repeating)
+create_bind({ "SUPER + Equal", "SUPER + ALT + right" }, fn.resize_active_window(10, 0), repeating)
+create_bind({ "SUPER + SHIFT + Minus", "SUPER + ALT + up" }, fn.resize_active_window(0, -10), repeating)
+create_bind({ "SUPER + SHIFT + Equal", "SUPER + ALT + down" }, fn.resize_active_window(0, 10), repeating)
+
+create_bind({ vars.kbMoveWindow, "SUPER + mouse:272" }, hl.dsp.window.drag(), mouse)
+create_bind({ vars.kbResizeWindow, "SUPER + mouse:273" }, hl.dsp.window.resize(), mouse)
+create_bind("CTRL + SUPER + Backslash", hl.dsp.window.center())
+create_bind("CTRL + SUPER + ALT + Backslash", function()
+    hl.dispatch(hl.dsp.window.resize(fn.resize_by_screen(55, 70)))
+    hl.dispatch(hl.dsp.window.center())
+end)
+create_bind(vars.kbWindowPip, function()
     local a = hl.get_active_window()
     if a then
         local pip = fn.move_actions(a) or {}
@@ -118,70 +114,79 @@ hl.bind(vars.kbWindowPip, function()
         end
     end
 end)
-hl.bind(vars.kbPinWindow, hl.dsp.window.pin())
-hl.bind(vars.kbWindowFullscreen, hl.dsp.window.fullscreen({ mode = "fullscreen" }))
-hl.bind(vars.kbWindowBorderedFullscreen, hl.dsp.window.fullscreen({ mode = "maximized" }))
-hl.bind(vars.kbToggleWindowFloating, hl.dsp.window.float())
-hl.bind(vars.kbCloseWindow, hl.dsp.window.close())
+create_bind(vars.kbPinWindow, hl.dsp.window.pin())
+create_bind(vars.kbWindowFullscreen, hl.dsp.window.fullscreen({ mode = "fullscreen" }))
+create_bind(vars.kbWindowBorderedFullscreen, hl.dsp.window.fullscreen({ mode = "maximized" }))
+create_bind(vars.kbToggleWindowFloating, hl.dsp.window.float())
+create_bind(vars.kbCloseWindow, hl.dsp.window.close())
 
 -- Special workspace toggles
-hl.bind(vars.kbSpecialWs, fn.toggle("specialws"))
-hl.bind(vars.kbSystemMonitorWs, fn.toggle("sysmon"))
-hl.bind(vars.kbMusicWs, fn.toggle("music"))
-hl.bind(vars.kbCommunicationWs, fn.toggle("communication"))
-hl.bind(vars.kbTodoWs, fn.toggle("todo"))
+create_bind(vars.kbSpecialWs, fn.toggle("specialws"))
+create_bind(vars.kbSystemMonitorWs, fn.toggle("sysmon"))
+create_bind(vars.kbMusicWs, fn.toggle("music"))
+create_bind(vars.kbCommunicationWs, fn.toggle("communication"))
+create_bind(vars.kbTodoWs, fn.toggle("todo"))
 
 -- Apps
-hl.bind(vars.kbTerminal, hl.dsp.exec_cmd(vars.terminal))
-hl.bind(vars.kbBrowser, hl.dsp.exec_cmd(vars.browser))
-hl.bind(vars.kbEditor, hl.dsp.exec_cmd(vars.editor))
-hl.bind(vars.kbFileExplorer, hl.dsp.exec_cmd(vars.fileExplorer))
-hl.bind("CTRL + ALT + V", hl.dsp.exec_cmd(vars.audioSettings))
+create_bind(vars.kbTerminal, hl.dsp.exec_cmd(vars.terminal))
+create_bind(vars.kbBrowser, hl.dsp.exec_cmd(vars.browser))
+create_bind(vars.kbEditor, hl.dsp.exec_cmd(vars.editor))
+create_bind(vars.kbFileExplorer, hl.dsp.exec_cmd(vars.fileExplorer))
+create_bind(vars.kbAudioSettings, hl.dsp.exec_cmd(vars.audioSettings))
 
 -- Utilities
-hl.bind("Print", hl.dsp.exec_cmd("caelestia screenshot"), { locked = true })
-hl.bind("SUPER + SHIFT + S", hl.dsp.global("caelestia:screenshotFreeze"))
-hl.bind("SUPER + SHIFT + ALT + S", hl.dsp.global("caelestia:screenshot"))
-hl.bind("SUPER + ALT + R", hl.dsp.exec_cmd("caelestia record -s"))
-hl.bind("CTRL + ALT + R", hl.dsp.exec_cmd("caelestia record"))
-hl.bind("SUPER + SHIFT + ALT + R", hl.dsp.exec_cmd("caelestia record -r"))
-hl.bind("SUPER + SHIFT + C", hl.dsp.exec_cmd("hyprpicker -a"))
+create_bind(vars.kbScreenshot, hl.dsp.exec_cmd("caelestia screenshot"), locked)
+create_bind(vars.kbScreenshotFreeze, hl.dsp.global("caelestia:screenshotFreeze"))
+create_bind(vars.kbScreenshotRegion, hl.dsp.global("caelestia:screenshot"))
+create_bind(vars.kbRecord, hl.dsp.exec_cmd("caelestia record"))
+create_bind(vars.kbRecordSound, hl.dsp.exec_cmd("caelestia record -s"))
+create_bind(vars.kbRecordRegion, hl.dsp.exec_cmd("caelestia record -r"))
+create_bind(vars.kbColorPicker, hl.dsp.exec_cmd("hyprpicker -a"))
+
+-- Brightness
+create_bind("XF86MonBrightnessUp", hl.dsp.global("caelestia:brightnessUp"), locked)
+create_bind("XF86MonBrightnessDown", hl.dsp.global("caelestia:brightnessDown"), locked)
+
+-- Media
+create_bind({ vars.kbMediaToggle, "XF86AudioPlay", "XF86AudioPause" }, hl.dsp.global("caelestia:mediaToggle"), locked)
+create_bind({ vars.kbMediaNext, "XF86AudioNext" }, hl.dsp.global("caelestia:mediaNext"), locked)
+create_bind({ vars.kbMediaPrev, "XF86AudioPrev" }, hl.dsp.global("caelestia:mediaPrev"), locked)
+create_bind({ vars.kbMediaStop, "XF86AudioStop" }, hl.dsp.global("caelestia:mediaStop"), locked)
 
 -- Volume
-hl.bind("XF86AudioMicMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"), { locked = true })
-hl.bind("XF86AudioMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), { locked = true })
-hl.bind("SUPER + SHIFT + M", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), { locked = true })
-hl.bind(
+create_bind({ vars.kbVolumeMute, "XF86AudioMute" }, hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), locked)
+create_bind("XF86AudioMicMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"), locked)
+create_bind(
     "XF86AudioRaiseVolume",
     hl.dsp.exec_cmd(
         "wpctl set-mute @DEFAULT_AUDIO_SINK@ 0; wpctl set-volume -l " ..
         (vars.volumeMax / 100) .. " @DEFAULT_AUDIO_SINK@ " .. vars.volumeStep .. "%+"
     ),
-    { locked = true, repeating = true }
+    locked_repeating
 )
-hl.bind(
+create_bind(
     "XF86AudioLowerVolume",
     hl.dsp.exec_cmd(
         "wpctl set-mute @DEFAULT_AUDIO_SINK@ 0; wpctl set-volume @DEFAULT_AUDIO_SINK@ " .. vars.volumeStep .. "%-"
     ),
-    { locked = true, repeating = true }
+    locked_repeating
 )
 
 -- Sleep
-hl.bind("SUPER + SHIFT + L", hl.dsp.exec_cmd(vars.sleepGestureCmd), { locked = true })
+create_bind(vars.kbSleepGestureCmd, hl.dsp.exec_cmd(vars.sleepGestureCmd), locked)
 
 -- Clipboard and emoji picker
-hl.bind("SUPER + V", hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard"))
-hl.bind("SUPER + ALT + V", hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard -d"))
-hl.bind("SUPER + Period", hl.dsp.exec_cmd("pkill fuzzel || caelestia emoji -p"))
-hl.bind(
+create_bind(vars.kbClipboard, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard"))
+create_bind(vars.kbClipboardDel, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard -d"))
+create_bind(vars.kbEmoji, hl.dsp.exec_cmd("pkill fuzzel || caelestia emoji -p"))
+create_bind(
     "CTRL + SHIFT + ALT + V",
     hl.dsp.exec_cmd('sleep 0.5s && ydotool type -d 1 "$(cliphist list | head -1 | cliphist decode)"'),
-    { locked = true }
+    locked
 )
 
 -- Testing
-hl.bind(
+create_bind(
     "SUPER + ALT + F12",
     hl.dsp.exec_cmd(
         "notify-send -u low -i dialog-information-symbolic 'Test notification' " ..

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -1,18 +1,20 @@
 local vars = require("variables")
 local fn   = require("utils.functions")
 
+
+-- Flags
 local locked           = { locked = true }
 local mouse            = { mouse = true }
 local release          = { release = true }
 local repeating        = { repeating = true }
 local locked_repeating = { locked = true, repeating = true }
 
-local function repeating_unless_mouse(key)
-    return not normalize_keybind(key):find("mouse", 1, true) and repeating or nil
+local function normalise_keybind(key)
+    return key:gsub("%s+", ""):lower()
 end
 
-local function normalize_keybind(key)
-    return key:gsub("%s+", ""):lower()
+local function repeating_unless_mouse(key)
+    return not normalise_keybind(key):find("mouse", 1, true) and repeating or nil
 end
 
 local function create_bind(keybinds, action, flags)
@@ -27,12 +29,12 @@ local function create_bind(keybinds, action, flags)
 end
 
 -- Launcher
-local launcher_default = normalize_keybind("SUPER + SUPER_L")
+local launcher_default = normalise_keybind("SUPER + SUPER_L")
 create_bind(
     vars.kbLauncher,
     hl.dsp.global("caelestia:launcher"),
     function(key)
-        return normalize_keybind(key) == launcher_default and release or nil
+        return normalise_keybind(key) == launcher_default and release or nil
     end
 )
 

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -70,8 +70,8 @@ create_bind(vars.kbPrevWs, hl.dsp.focus({ workspace = "-1" }), repeating_unless_
 create_bind(vars.kbNextWs, hl.dsp.focus({ workspace = "+1" }), repeating_unless_mouse)
 
 -- Go to workspace group -1/+1
-create_bind("CTRL + SUPER + mouse_up", hl.dsp.focus({ workspace = "-10" }))
-create_bind("CTRL + SUPER + mouse_down", hl.dsp.focus({ workspace = "+10" }))
+create_bind(vars.kbPrevWsGroup, hl.dsp.focus({ workspace = "-10" }), repeating_unless_mouse)
+create_bind(vars.kbNextWsGroup, hl.dsp.focus({ workspace = "+10" }), repeating_unless_mouse)
 
 -- Move window to workspace -1/+1
 create_bind(vars.kbMoveWinToWsNext, hl.dsp.window.move({ workspace = "+1" }), repeating_unless_mouse)

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -17,13 +17,26 @@ local function repeating_unless_mouse(key)
     return not normalise_keybind(key):find("mouse", 1, true) and repeating or nil
 end
 
+local function flatten_keybinds(keybinds, keys)
+    keys = keys or {}
+
+    if type(keybinds) == "table" then
+        for _, keybind in ipairs(keybinds) do
+            flatten_keybinds(keybind, keys)
+        end
+    elseif keybinds ~= nil then
+        keys[#keys + 1] = keybinds
+    end
+
+    return keys
+end
+
 local function create_bind(keybinds, action, flags)
-    local keys = type(keybinds) == "string" and { keybinds } or keybinds
     local get_flags = type(flags) == "function" and flags or function()
         return flags
     end
 
-    for _, key in ipairs(keys) do
+    for _, key in ipairs(flatten_keybinds(keybinds)) do
         hl.bind(key, action, get_flags(key))
     end
 end

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -181,7 +181,7 @@ create_bind(
 )
 
 -- Sleep
-create_bind(vars.kbSleepGestureCmd, hl.dsp.exec_cmd(vars.sleepGestureCmd), locked)
+create_bind(vars.kbSleep, hl.dsp.exec_cmd(vars.sleepGestureCmd), locked)
 
 -- Clipboard and emoji picker
 create_bind(vars.kbClipboard, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard"))

--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -7,16 +7,34 @@ local release          = { release = true }
 local repeating        = { repeating = true }
 local locked_repeating = { locked = true, repeating = true }
 
+local function repeating_unless_mouse(key)
+    return not normalize_keybind(key):find("mouse", 1, true) and repeating or nil
+end
+
+local function normalize_keybind(key)
+    return key:gsub("%s+", ""):lower()
+end
+
 local function create_bind(keybinds, action, flags)
     local keys = type(keybinds) == "string" and { keybinds } or keybinds
+    local get_flags = type(flags) == "function" and flags or function()
+        return flags
+    end
 
-    for _, keybind in ipairs(keybinds) do
-        hl.bind(keybind, action, flags)
+    for _, key in ipairs(keys) do
+        hl.bind(key, action, get_flags(key))
     end
 end
 
 -- Launcher
-create_bind("SUPER + SUPER_L", hl.dsp.global("caelestia:launcher"), release)
+local launcher_default = normalize_keybind("SUPER + SUPER_L")
+create_bind(
+    vars.kbLauncher,
+    hl.dsp.global("caelestia:launcher"),
+    function(key)
+        return normalize_keybind(key) == launcher_default and release or nil
+    end
+)
 
 -- Misc
 create_bind(vars.kbSession, hl.dsp.global("caelestia:session"))
@@ -48,41 +66,29 @@ for i = 1, 10 do
 end
 
 -- Go to workspace -1/+1
-create_bind("SUPER + mouse_up", hl.dsp.focus({ workspace = "-1" }))
-create_bind("SUPER + mouse_down", hl.dsp.focus({ workspace = "+1" }))
-create_bind({ vars.kbPrevWs, "SUPER + Page_Up" }, hl.dsp.focus({ workspace = "-1" }), repeating)
-create_bind({ vars.kbNextWs, "SUPER + Page_Down" }, hl.dsp.focus({ workspace = "+1" }), repeating)
+create_bind(vars.kbPrevWs, hl.dsp.focus({ workspace = "-1" }), repeating_unless_mouse)
+create_bind(vars.kbNextWs, hl.dsp.focus({ workspace = "+1" }), repeating_unless_mouse)
 
 -- Go to workspace group -1/+1
 create_bind("CTRL + SUPER + mouse_up", hl.dsp.focus({ workspace = "-10" }))
 create_bind("CTRL + SUPER + mouse_down", hl.dsp.focus({ workspace = "+10" }))
 
 -- Move window to workspace -1/+1
-create_bind("SUPER + ALT + mouse_up", hl.dsp.window.move({ workspace = "-1" }))
-create_bind("SUPER + ALT + mouse_down", hl.dsp.window.move({ workspace = "+1" }))
-create_bind(
-    { "SUPER + ALT + Page_Down", "CTRL + SUPER + SHIFT + right" },
-    hl.dsp.window.move({ workspace = "+1" }),
-    repeating
-)
-create_bind(
-    { "SUPER + ALT + Page_Up", "CTRL + SUPER + SHIFT + left" },
-    hl.dsp.window.move({ workspace = "-1" }),
-    repeating
-)
+create_bind(vars.kbMoveWinToWsNext, hl.dsp.window.move({ workspace = "+1" }), repeating_unless_mouse)
+create_bind(vars.kbMoveWinToWsPrev, hl.dsp.window.move({ workspace = "-1" }), repeating_unless_mouse)
 
 -- Move window to/from special workspace
-create_bind({ vars.kbMoveWinToWsSpecial, "CTRL + SUPER + SHIFT + up" }, hl.dsp.window.move({ workspace = "special:special" }))
-create_bind("CTRL + SUPER + SHIFT + down", hl.dsp.window.move({ workspace = "e+0" }))
+create_bind(vars.kbMoveWinToWsSpecial, hl.dsp.window.move({ workspace = "special:special" }))
+create_bind(vars.kbMoveWinFromWsSpecial, hl.dsp.window.move({ workspace = "e+0" }))
 
 -- Window groups
-create_bind(vars.kbWindowGroupCycleNext, hl.dsp.window.cycle_next(), repeating)
-create_bind(vars.kbWindowGroupCyclePrev, hl.dsp.window.cycle_next({ next = false }), repeating)
-create_bind("CTRL + ALT + Tab", hl.dsp.group.next(), repeating)
-create_bind("CTRL + SHIFT + ALT + Tab", hl.dsp.group.prev(), repeating)
+create_bind(vars.kbWindowCycleNext, hl.dsp.window.cycle_next(), repeating)
+create_bind(vars.kbWindowCyclePrev, hl.dsp.window.cycle_next({ next = false }), repeating)
+create_bind(vars.kbWindowGroupCycleNext, hl.dsp.group.next(), repeating)
+create_bind(vars.kbWindowGroupCyclePrev, hl.dsp.group.prev(), repeating)
 create_bind(vars.kbToggleGroup, hl.dsp.group.toggle())
 create_bind(vars.kbUngroup, hl.dsp.window.move({ out_of_group = true }))
-create_bind("SUPER + SHIFT + Comma", hl.dsp.group.lock_active())
+create_bind(vars.kbGroupLockActive, hl.dsp.group.lock_active())
 
 -- Window actions
 for _, dir in ipairs({ "left", "right", "up", "down" }) do
@@ -90,15 +96,15 @@ for _, dir in ipairs({ "left", "right", "up", "down" }) do
     create_bind("SUPER + SHIFT + " .. dir, hl.dsp.window.move({ direction = dir }))
 end
 
-create_bind({ "SUPER + Minus", "SUPER + ALT + left" }, fn.resize_active_window(-10, 0), repeating)
-create_bind({ "SUPER + Equal", "SUPER + ALT + right" }, fn.resize_active_window(10, 0), repeating)
-create_bind({ "SUPER + SHIFT + Minus", "SUPER + ALT + up" }, fn.resize_active_window(0, -10), repeating)
-create_bind({ "SUPER + SHIFT + Equal", "SUPER + ALT + down" }, fn.resize_active_window(0, 10), repeating)
+create_bind(vars.kbWindowDecreaseWidth, fn.resize_active_window(-10, 0), repeating)
+create_bind(vars.kbWindowIncreaseWidth, fn.resize_active_window(10, 0), repeating)
+create_bind(vars.kbWindowDecreaseHeight, fn.resize_active_window(0, -10), repeating)
+create_bind(vars.kbWindowIncreaseHeight, fn.resize_active_window(0, 10), repeating)
 
 create_bind({ vars.kbMoveWindow, "SUPER + mouse:272" }, hl.dsp.window.drag(), mouse)
 create_bind({ vars.kbResizeWindow, "SUPER + mouse:273" }, hl.dsp.window.resize(), mouse)
-create_bind("CTRL + SUPER + Backslash", hl.dsp.window.center())
-create_bind("CTRL + SUPER + ALT + Backslash", function()
+create_bind(vars.kbCenterWindow, hl.dsp.window.center())
+create_bind(vars.kbNormalizeWindow, function()
     hl.dispatch(hl.dsp.window.resize(fn.resize_by_screen(55, 70)))
     hl.dispatch(hl.dsp.window.center())
 end)
@@ -180,7 +186,7 @@ create_bind(vars.kbClipboard, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboa
 create_bind(vars.kbClipboardDel, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard -d"))
 create_bind(vars.kbEmoji, hl.dsp.exec_cmd("pkill fuzzel || caelestia emoji -p"))
 create_bind(
-    "CTRL + SHIFT + ALT + V",
+    vars.kbClipboardPasteLatest,
     hl.dsp.exec_cmd('sleep 0.5s && ydotool type -d 1 "$(cliphist list | head -1 | cliphist decode)"'),
     locked
 )

--- a/hypr/variables.lua
+++ b/hypr/variables.lua
@@ -69,6 +69,8 @@ return {
     kbGoToWsGroup              = "CTRL + SUPER",
     kbNextWs                   = { "SUPER + mouse_down", "CTRL + SUPER + Right", "SUPER + Page_Down" },
     kbPrevWs                   = { "SUPER + mouse_up", "CTRL + SUPER + Left", "SUPER + Page_Up" },
+    kbNextWsGroup              = "CTRL + SUPER + mouse_down",
+    kbPrevWsGroup              = "CTRL + SUPER + mouse_up",
 
     -- Window Group
     kbWindowCycleNext          = "ALT + TAB",

--- a/hypr/variables.lua
+++ b/hypr/variables.lua
@@ -61,6 +61,7 @@ return {
     -- Workspaces
     kbMoveWinToWs              = "SUPER + ALT",
     kbMoveWinToWsGroup         = "CTRL + SUPER + ALT",
+    kbMoveWinToWsSpecial       = "SUPER + ALT + S",
     kbGoToWs                   = "SUPER",
     kbGoToWsGroup              = "CTRL + SUPER",
     kbNextWs                   = "CTRL + SUPER + Right",
@@ -94,6 +95,23 @@ return {
     kbBrowser                  = "SUPER + W",
     kbEditor                   = "SUPER + C",
     kbFileExplorer             = "SUPER + E",
+    kbAudioSettings            = "CTRL + ALT + V",
+
+    -- Utilities
+    kbScreenshot               = "Print",
+    kbScreenshotFreeze         = "SUPER + SHIFT + S",
+    kbScreenshotRegion         = "SUPER + SHIFT + ALT + S",
+    kbRecord                   = "CTRL + ALT + R",
+    kbRecordSound              = "SUPER + ALT + R",
+    kbRecordRegion             = "SUPER + SHIFT + ALT + R",
+    kbColorPicker              = "SUPER + SHIFT + C",
+
+    -- Media
+    kbMediaToggle              = "CTRL + SUPER + Space",
+    kbMediaNext                = "CTRL + SUPER + Equal",
+    kbMediaPrev                = "CTRL + SUPER + Minus",
+    kbMediaStop                = "CTRL + SUPER + Backspace",
+    kbVolumeMute               = "SUPER + SHIFT + M",
 
     -- Misc
     kbSession                  = "CTRL + ALT + Delete",
@@ -102,4 +120,10 @@ return {
     kbShowPanels               = "SUPER + K",
     kbLock                     = "SUPER + L",
     kbRestoreLock              = "SUPER + ALT + L",
+    kbSleepGestureCmd          = "SUPER + SHIFT + L",
+
+    -- Clipboard and emoji picker
+    kbClipboard                = "SUPER + V",
+    kbClipboardDel             = "SUPER + ALT + V",
+    kbEmoji                    = "SUPER + Period",
 }

--- a/hypr/variables.lua
+++ b/hypr/variables.lua
@@ -136,7 +136,7 @@ return {
     kbShowPanels               = "SUPER + K",
     kbLock                     = "SUPER + L",
     kbRestoreLock              = "SUPER + ALT + L",
-    kbSleepGestureCmd          = "SUPER + SHIFT + L",
+    kbSleep                    = "SUPER + SHIFT + L",
 
     -- Clipboard and emoji picker
     kbClipboard                = "SUPER + V",

--- a/hypr/variables.lua
+++ b/hypr/variables.lua
@@ -61,26 +61,39 @@ return {
     -- Workspaces
     kbMoveWinToWs              = "SUPER + ALT",
     kbMoveWinToWsGroup         = "CTRL + SUPER + ALT",
-    kbMoveWinToWsSpecial       = "SUPER + ALT + S",
+    kbMoveWinToWsSpecial       = { "SUPER + ALT + S", "CTRL + SUPER + SHIFT + Up" },
+    kbMoveWinFromWsSpecial     = "CTRL + SUPER + SHIFT + Down",
+    kbMoveWinToWsNext          = { "SUPER + ALT + mouse_down", "SUPER + ALT + Page_Down", "CTRL + SUPER + SHIFT + Right" },
+    kbMoveWinToWsPrev          = { "SUPER + ALT + mouse_up", "SUPER + ALT + Page_Up", "CTRL + SUPER + SHIFT + Left" },
     kbGoToWs                   = "SUPER",
     kbGoToWsGroup              = "CTRL + SUPER",
-    kbNextWs                   = "CTRL + SUPER + Right",
-    kbPrevWs                   = "CTRL + SUPER + Left",
+    kbNextWs                   = { "SUPER + mouse_down", "CTRL + SUPER + Right", "SUPER + Page_Down" },
+    kbPrevWs                   = { "SUPER + mouse_up", "CTRL + SUPER + Left", "SUPER + Page_Up" },
 
     -- Window Group
-    kbWindowGroupCycleNext     = "ALT + TAB",
-    kbWindowGroupCyclePrev     = "SHIFT + ALT + TAB",
+    kbWindowCycleNext          = "ALT + TAB",
+    kbWindowCyclePrev          = "SHIFT + ALT + TAB",
+    kbWindowGroupCycleNext     = "CTRL + ALT + TAB",
+    kbWindowGroupCyclePrev     = "CTRL + SHIFT + ALT + TAB",
     kbUngroup                  = "SUPER + U",
     kbToggleGroup              = "SUPER + Comma",
+    kbGroupLockActive          = "SUPER + SHIFT + Comma",
 
-    -- Window Action
+    -- Window Actions
+    kbWindowDecreaseWidth      = { "SUPER + Minus", "SUPER + ALT + Left" },
+    kbWindowIncreaseWidth      = { "SUPER + Equal", "SUPER + ALT + Right" },
+    kbWindowDecreaseHeight     = { "SUPER + SHIFT + Minus", "SUPER + ALT + Up" },
+    kbWindowIncreaseHeight     = { "SUPER + SHIFT + Equal", "SUPER + ALT + Down" },
+
     kbMoveWindow               = "SUPER + Z",
     kbResizeWindow             = "SUPER + X",
-    kbWindowPip                = "SUPER + ALT + backslash",
+    kbCenterWindow             = "CTRL + SUPER + Backslash",
+    kbNormalizeWindow          = "CTRL + SUPER + ALT + Backslash",
+    kbWindowPip                = "SUPER + ALT + Backslash",
     kbPinWindow                = "SUPER + P",
     kbWindowFullscreen         = "SUPER + F",
     kbWindowBorderedFullscreen = "SUPER + ALT + F",
-    kbToggleWindowFloating     = "SUPER + ALT + space",
+    kbToggleWindowFloating     = "SUPER + ALT + Space",
     kbCloseWindow              = "SUPER + Q",
 
     -- Special workspaces toggles
@@ -114,6 +127,7 @@ return {
     kbVolumeMute               = "SUPER + SHIFT + M",
 
     -- Misc
+    kbLauncher                 = "SUPER + SUPER_L",
     kbSession                  = "CTRL + ALT + Delete",
     kbShowSidebar              = "SUPER + N",
     kbClearNotifs              = "CTRL + ALT + C",
@@ -125,5 +139,6 @@ return {
     -- Clipboard and emoji picker
     kbClipboard                = "SUPER + V",
     kbClipboardDel             = "SUPER + ALT + V",
+    kbClipboardPasteLatest     = "CTRL + SHIFT + ALT + V",
     kbEmoji                    = "SUPER + Period",
 }

--- a/hypr/variables.lua
+++ b/hypr/variables.lua
@@ -58,15 +58,19 @@ return {
     ---- KEYBINDS ----
     ------------------
 
-    -- Workspaces
+    -- Modifier only, the actual binds will be mod + 0-9. These should be strings and not arrays.
+    kbGoToWs                   = "SUPER",
+    kbGoToWsGroup              = "CTRL + SUPER",
     kbMoveWinToWs              = "SUPER + ALT",
     kbMoveWinToWsGroup         = "CTRL + SUPER + ALT",
+
+    -- All the following binds can be either an array of binds to bind multiple keys, or a single string.
+
+    -- Workspaces
     kbMoveWinToWsSpecial       = { "SUPER + ALT + S", "CTRL + SUPER + SHIFT + Up" },
     kbMoveWinFromWsSpecial     = "CTRL + SUPER + SHIFT + Down",
     kbMoveWinToWsNext          = { "SUPER + ALT + mouse_down", "SUPER + ALT + Page_Down", "CTRL + SUPER + SHIFT + Right" },
     kbMoveWinToWsPrev          = { "SUPER + ALT + mouse_up", "SUPER + ALT + Page_Up", "CTRL + SUPER + SHIFT + Left" },
-    kbGoToWs                   = "SUPER",
-    kbGoToWsGroup              = "CTRL + SUPER",
     kbNextWs                   = { "SUPER + mouse_down", "CTRL + SUPER + Right", "SUPER + Page_Down" },
     kbPrevWs                   = { "SUPER + mouse_up", "CTRL + SUPER + Left", "SUPER + Page_Up" },
     kbNextWsGroup              = "CTRL + SUPER + mouse_down",


### PR DESCRIPTION
## Summary

Refactors keybinds for improved organization and readability.

- introduce a `create_bind` helper function to simplify definitions and allow binding multiple keys to a single action
- extract keybind flags into dedicated variables for readability and reduced repetition
- add more keybind definitions to `variables.lua`, making configuration easier
- group related keybinds and utilize loops to reduce duplication
- replace `kbWindowGroupCycleNext`/`kbWindowGroupCyclePrev` with new variables and utilize them for correctly cycling through window groups

The only keybind this PR adds that was not previously defined is `CTRL + SUPER + Backspace` for dispatching the global `caelestia:mediaStop`. This is to stay consistent with all other media functions having variable keybinds.  The keybind uses `CTRL + SUPER` as the other media binds do,  and `Backspace` is used for it's proximity to the `mediaNext`/`mediaPrev` keybinds (`Equal` and `Minus`, respectively).