### PR TITLE
pipewire: use pwvucontrol

### DIFF
--- a/hypr/variables.lua
+++ b/hypr/variables.lua
@@ -10,7 +10,7 @@ return {
     browser                    = "firefox",
     editor                     = "codium",
     fileExplorer               = "thunar",
-    audioSettings              = "pavucontrol",
+    audioSettings              = "pwvucontrol",
 
     -- Touchpad
     touchpadDisableTyping      = true,

--- a/manifest.toml
+++ b/manifest.toml
@@ -137,7 +137,7 @@ packages = [
     "pipewire-alsa",
     "pipewire-jack",
     "wireplumber",
-    "pavucontrol",
+    "pwvucontrol",
 ]
 
 [[components]]


### PR DESCRIPTION
## Summary

Replaces `pavucontrol` with [`pwvucontrol`](https://github.com/saivert/pwvucontrol) as the default audio control application.

Paired with caelestia-dots/shell#1820, which aligns the shell's default audio app and README.

## Rationale

`pwvucontrol` is designed specifically for PipeWire and WirePlumber, making it a better match for the full PipeWire audio stack than a control application using the PulseAudio compatibility layer.

It has fewer direct dependencies and automatically follows Caelestia's configured GTK theme, providing better visual integration without additional configuration.

## Testing

- Confirmed `pwvucontrol` launches through the audio settings keybind.
- Confirmed the existing window rule makes it float correctly.
- Confirmed device and application volume controls work as expected.
- Confirmed it follows the theme.

## Side effects

On vanilla Arch Linux, `pwvucontrol` is available through the AUR rather than the official repositories. Several other packages in the `manifest.toml` come from the AUR already (`darkly-bin`, etc.).

## Screenshot

<img width="2473" height="1404" alt="screenshot-20260728-113546" src="https://github.com/user-attachments/assets/681f9bf8-d9c7-4e41-98f8-eca433d75c30" />