### PR TITLE
refactor: use clipboard paste-latest CLI command

### DIFF
--- a/hypr/hyprland/keybinds.lua
+++ b/hypr/hyprland/keybinds.lua
@@ -200,11 +200,7 @@ create_bind(vars.kbSleep, hl.dsp.exec_cmd(vars.sleepGestureCmd), locked)
 create_bind(vars.kbClipboard, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard"))
 create_bind(vars.kbClipboardDel, hl.dsp.exec_cmd("pkill fuzzel || caelestia clipboard -d"))
 create_bind(vars.kbEmoji, hl.dsp.exec_cmd("pkill fuzzel || caelestia emoji -p"))
-create_bind(
-    vars.kbClipboardPasteLatest,
-    hl.dsp.exec_cmd('sleep 0.5s && ydotool type -d 1 "$(cliphist list | head -1 | cliphist decode)"'),
-    locked
-)
+create_bind(vars.kbClipboardPasteLatest, hl.dsp.exec_cmd("sleep 0.5s && caelestia clipboard -l"), locked)
 
 -- Testing
 create_bind(


### PR DESCRIPTION
## Summary

Replace the inline `ydotool` shell pipeline for the "paste latest"binding with the new `caelestia clipboard --paste-latest` command.

This keeps the binding simple and moves the implementation into the CLI.

## Depends on

- https://github.com/caelestia-dots/cli/pull/143
- https://github.com/caelestia-dots/shell/pull/1810

**Note:** This PR should be merged after caelestia-dots/cli#143 and
caelestia-dots/shell#1810.