### PR TITLE
docs: improve github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -6,7 +6,11 @@ title: "[FEATURE] "
 body:
     - type: markdown
       attributes:
-          value: "NOTE: Please write in **English**."
+          value: |
+              **NOTE**: Please write in **English**.
+
+              > [!IMPORTANT]
+              > If you're requesting a feature that pertains to the shell itself (bar, dashboard, launcher, etc) rather than the dotfiles, please create a feature request in the [shell repo](https://github.com/caelestia-dots/shell/issues) instead.
 
     - type: textarea
       attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -6,47 +6,66 @@ title: "[BUG] "
 body:
     - type: markdown
       attributes:
-          value: "**Welcome to submit a new issue!**\n- It takes only 3 steps, so please be patient :)\n- Tip: If your issue is not a feature request and is not an issue with the dots (e.g. \"how do I use X feature\"), please use [Discussions](https://github.com/caelestia-dots/shell/discussions) instead."
+          value: |
+              **Welcome to submitting a new issue!**
+              - It takes only a few steps, so please be patient and read through everything :)
+              - **Tip**: If your issue is not a feature request and is not an issue with the dots (e.g. "how do I use X feature"), please use [Discussions](https://github.com/caelestia-dots/shell/discussions) instead.
+
+              > [!IMPORTANT]
+              > If your issue pertains to the shell itself (bar, dashboard, launcher, etc) rather than the dotfiles, please create an issue for the [shell repo](https://github.com/caelestia-dots/shell/issues) instead.
     - type: checkboxes
       attributes:
-          label: "Step 1. Before you submit"
-          description: "Hint: The 2nd and 3rd checkbox is **not** forcely required as you may have failed to do so."
+          label: "1. Before you submit"
+          description: "Hint: The 2nd and 3rd boxes are **not** forcibly required as you may have been unable to do so."
           options:
               - label: I have read the above instructions and am sure that this is supposed to be posted here.
                 required: true
               - label: I've successfully updated to the latest versions following the [updating guide](https://github.com/caelestia-dots/caelestia?tab=readme-ov-file#updating).
-                required: false # Not required cuz user may have failed to do so
+                required: false # Not required since user may have failed to do so
               - label: I've successfully updated the system packages to the latest.
-                required: false # Not required cuz user may have failed to do so
+                required: false # Not required since user may have failed to do so
               - label: I've ticked the checkboxes without reading their contents
                 required: false # Obviously
 
     - type: textarea
       attributes:
-          label: "Step 2. Version info"
+          label: "2. Version info"
           description: "Run `caelestia -v` and paste the result below."
-          value: "<details><summary>Version info</summary>\n\n```\n<!-- Run `caelestia -v` and paste the result here! -->\n```\n\n</details>"
+          placeholder: "Paste the output of `caelestia -v` here!"
+          render: text
       validations:
           required: true
-
-    - type: markdown
-      attributes:
-          value: |
-              **Tips for the following Step 3**
-              1. Use `LANG=C LC_ALL=C` to get the output of a command in English, eg. `LANG=C LC_ALL=C date` displays time in English.
-              2. If it throws errors, **PLEASE**, attach logs and describe in detail if possible.
-                 - Something happened to the shell (bar, dashboard, etc)? Run `caelestia shell -l` WITHOUT exiting the shell for logs.
-                 - Installation failed? Run installation again for logs.
-                 - You may use more code blocks when needed.
-              3. In case you are confused, the `<details>`, `<summary>`, `</summary>`, `</details>` are HTML tags for folding the logs (typically very long) inside. Please do not touch them (unless you know what you are doing).
-              4. If the logs are suuuuuuper long, consider using an online pastebin service instead.
 
     - type: textarea
       attributes:
-          label: "Step 3. Describe the issue"
-          value: "\n<!-- Firsly describe your issue here! -->\n\n<details><summary>Logs</summary>\n\n```\n<!-- Put your log content here!-->\n```\n\n</details>"
+          label: "3a. Describe the issue"
+          placeholder: "Describe your issue here!"
       validations:
           required: true
+
+    - type: textarea
+      attributes:
+          label: "3b. Logs content"
+          description: |
+              **Tips for pasting logs:**
+              1. Use `LANG=C LC_ALL=C` to get the output of a command in English.
+                 - For example, `LANG=C LC_ALL=C date` displays the current date and time in English.
+              2. If it throws errors, **PLEASE**, attach logs and describe in detail if possible.
+                 - Installation failed? Run installation again for logs.
+                 - You may use more code blocks when needed.
+              3. In case you are confused, `<details>` and `<summary>` are HTML tags for folding the (typically very long) logs inside. Please do not touch them (unless you know what you are doing).
+              4. If the logs are suuuuuuper long, consider using an online pastebin service instead (e.g., https://pastes.dev/).
+          value: |
+              <details><summary>Logs</summary>
+
+              ```
+              <!-- Put your log content here!-->
+              ```
+
+              </details>
+          render: text
+      validations:
+          required: false # Logs may not be available
 
     - type: checkboxes
       attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -38,14 +38,14 @@ body:
 
     - type: textarea
       attributes:
-          label: "3a. Describe the issue"
+          label: "3. Describe the issue"
           placeholder: "Describe your issue here!"
       validations:
           required: true
 
     - type: textarea
       attributes:
-          label: "3b. Logs content"
+          label: "4. Logs content"
           description: |
               **Tips for pasting logs:**
               1. Use `LANG=C LC_ALL=C` to get the output of a command in English.


### PR DESCRIPTION
## Summary

- adds notes to both `feature.yml` and `issue.yml` directing users to the shell repo for issues that are purely shell-related
- clarifies steps and improves wording
- changes version to use `placeholder` instead of default text with `value`, allowing the `required` validation to work properly
  - while this no longer collapses version content, it should always be ~30 lines at the maximum which isn't unreasonable
- separates the issue description and log content fields to allow making issue descriptions actually required
- formats strings into multi-line instead of chaining newline separators

**Note:** I understand parts of this (other than the note for directing users to the shell repo) are rather opinionated, and expect there are ways this could be done differently. I'm open to feedback on this, as I expect Sora will have changes to request, but wanted to get something started on this regardless.